### PR TITLE
feat(dev-cycle): add resumable planning and execution extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .references/
 .worktrees/
 node_modules/
+.pi/dev-cycles/
 
 # Boardroom smoke-test / meeting transcripts (timestamped outputs)
 boardroom/debates/*.json

--- a/.pi/extensions/dev-cycle/agents.test.ts
+++ b/.pi/extensions/dev-cycle/agents.test.ts
@@ -1,0 +1,57 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { discoverTeamAgents, selectImplementationOrchestrator, summarizeAgents } from "./agents.js";
+
+function writeAgent(filePath: string, name: string, description: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `---\nname: "${name}"\ndescription: "${description}"\nmodel: "gpt-5.4:medium"\n---\n\nPrompt.\n`,
+    "utf-8",
+  );
+}
+
+describe("agent discovery", () => {
+  let tempDir = "";
+
+  afterEach(() => {
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+    delete process.env.PI_AGENT_DIR;
+  });
+
+  it("discovers built-in, user, and project agents", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-cycle-agents-"));
+    writeAgent(path.join(tempDir, "agents", "engineering", "orchestrator.md"), "Engineering Orchestrator", "Runs work.");
+    writeAgent(path.join(tempDir, ".pi", "agents", "local.md"), "Local Specialist", "Local work.");
+
+    const userDir = path.join(tempDir, "user-home");
+    process.env.PI_AGENT_DIR = userDir;
+    writeAgent(path.join(userDir, "agents", "global.md"), "Global Specialist", "Global work.");
+
+    const agents = discoverTeamAgents(tempDir);
+    expect(agents.map((agent) => agent.name)).toEqual([
+      "Engineering Orchestrator",
+      "Global Specialist",
+      "Local Specialist",
+    ]);
+  });
+
+  it("prefers engineering orchestrator when choosing implementation entry point", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-cycle-orchestrator-"));
+    writeAgent(path.join(tempDir, "agents", "engineering", "orchestrator.md"), "Engineering Orchestrator", "Runs work.");
+    writeAgent(path.join(tempDir, "agents", "engineering", "developer.md"), "Developer", "Builds work.");
+
+    const orchestrator = selectImplementationOrchestrator(discoverTeamAgents(tempDir));
+    expect(orchestrator?.name).toBe("Engineering Orchestrator");
+  });
+
+  it("summarizes available team members", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-cycle-summary-"));
+    writeAgent(path.join(tempDir, "agents", "engineering", "developer.md"), "Developer", "Builds work.");
+    const summary = summarizeAgents(discoverTeamAgents(tempDir));
+    expect(summary).toContain("Developer");
+    expect(summary).toContain("built-in");
+  });
+});

--- a/.pi/extensions/dev-cycle/agents.ts
+++ b/.pi/extensions/dev-cycle/agents.ts
@@ -1,0 +1,118 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { DiscoveredAgent } from "./types.js";
+
+interface Frontmatter {
+  name?: string;
+  description?: string;
+  model?: string;
+  tools?: string;
+}
+
+function slugify(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function parseFrontmatter(content: string): { frontmatter: Frontmatter; body: string } {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, body: content };
+
+  const frontmatter: Frontmatter = {};
+  for (const line of match[1].split("\n")) {
+    const kv = line.match(/^(\w[\w_]*)\s*:\s*"?([^"]*)"?\s*$/);
+    if (kv) {
+      (frontmatter as Record<string, string>)[kv[1]] = kv[2].trim();
+    }
+  }
+
+  return { frontmatter, body: match[2] };
+}
+
+function loadMarkdownAgents(
+  dir: string,
+  source: DiscoveredAgent["source"],
+  category: string,
+): DiscoveredAgent[] {
+  if (!fs.existsSync(dir)) return [];
+  const agents: DiscoveredAgent[] = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+    if (!entry.name.endsWith(".md")) continue;
+
+    const filePath = path.join(dir, entry.name);
+    const content = fs.readFileSync(filePath, "utf-8");
+    const { frontmatter, body } = parseFrontmatter(content);
+    if (!frontmatter.name || !frontmatter.description) continue;
+
+    agents.push({
+      name: frontmatter.name,
+      slug: slugify(frontmatter.name),
+      description: frontmatter.description,
+      category,
+      source,
+      model: frontmatter.model,
+      tools: frontmatter.tools?.split(",").map((item) => item.trim()).filter(Boolean),
+      systemPrompt: body,
+      filePath,
+    });
+  }
+
+  return agents;
+}
+
+function loadBuiltInAgents(cwd: string): DiscoveredAgent[] {
+  const root = path.join(cwd, "agents");
+  if (!fs.existsSync(root)) return [];
+
+  const agents: DiscoveredAgent[] = [];
+  for (const categoryEntry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!categoryEntry.isDirectory()) continue;
+    agents.push(...loadMarkdownAgents(path.join(root, categoryEntry.name), "built-in", categoryEntry.name));
+  }
+  return agents;
+}
+
+function loadProjectAgents(cwd: string): DiscoveredAgent[] {
+  const dir = path.join(cwd, ".pi", "agents");
+  return loadMarkdownAgents(dir, "project", "project");
+}
+
+function loadUserAgents(): DiscoveredAgent[] {
+  const agentHome = process.env.PI_AGENT_DIR || path.join(os.homedir(), ".pi", "agent");
+  return loadMarkdownAgents(path.join(agentHome, "agents"), "user", "user");
+}
+
+export function discoverTeamAgents(cwd: string): DiscoveredAgent[] {
+  const merged = new Map<string, DiscoveredAgent>();
+
+  for (const agent of loadBuiltInAgents(cwd)) merged.set(agent.name, agent);
+  for (const agent of loadUserAgents()) merged.set(agent.name, agent);
+  for (const agent of loadProjectAgents(cwd)) merged.set(agent.name, agent);
+
+  return Array.from(merged.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function selectImplementationOrchestrator(agents: DiscoveredAgent[]): DiscoveredAgent | null {
+  const preferred = [
+    "Engineering Orchestrator",
+    "engineering-orchestrator",
+    "Developer",
+  ];
+
+  for (const needle of preferred) {
+    const found = agents.find((agent) => agent.name === needle || agent.slug === needle);
+    if (found) return found;
+  }
+
+  return agents[0] ?? null;
+}
+
+export function summarizeAgents(agents: DiscoveredAgent[], maxItems = 12): string {
+  if (agents.length === 0) return "none";
+  const listed = agents.slice(0, maxItems);
+  const summary = listed.map((agent) => `${agent.name} [${agent.source}/${agent.category}]`).join(", ");
+  if (agents.length <= maxItems) return summary;
+  return `${summary}, +${agents.length - maxItems} more`;
+}

--- a/.pi/extensions/dev-cycle/artifacts.test.ts
+++ b/.pi/extensions/dev-cycle/artifacts.test.ts
@@ -1,0 +1,46 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureRuntimeGitignore, readCycle, readGraph, writeCycle, writeGraph, writePlanFile } from "./artifacts.js";
+import { createExecutionGraph } from "./graph.js";
+import { createCycleRecord } from "./stages.js";
+
+describe("artifacts", () => {
+  let tempDir = "";
+
+  afterEach(() => {
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("writes and reads cycles and graphs", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-cycle-artifacts-"));
+    const cycle = createCycleRecord(tempDir, "Fix cycle status output");
+    writeCycle(tempDir, cycle);
+
+    const graph = createExecutionGraph(cycle.slug, cycle.title);
+    writeGraph(tempDir, cycle.slug, graph);
+
+    expect(readCycle(tempDir, cycle.slug)?.slug).toBe(cycle.slug);
+    expect(readGraph(tempDir, cycle.slug)?.rootId).toBe(graph.rootId);
+  });
+
+  it("adds runtime storage to gitignore once", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-cycle-gitignore-"));
+    fs.writeFileSync(path.join(tempDir, ".gitignore"), "node_modules/\n", "utf-8");
+
+    ensureRuntimeGitignore(tempDir);
+    ensureRuntimeGitignore(tempDir);
+
+    const content = fs.readFileSync(path.join(tempDir, ".gitignore"), "utf-8");
+    expect(content.match(/\.pi\/dev-cycles\//g)).toHaveLength(1);
+  });
+
+  it("writes plan files into plans directory", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-cycle-plan-"));
+    const planPath = writePlanFile(tempDir, "my-cycle", "# Plan");
+
+    expect(planPath).toBe(path.join(tempDir, "plans", "my-cycle.md"));
+    expect(fs.readFileSync(planPath, "utf-8")).toBe("# Plan");
+  });
+});

--- a/.pi/extensions/dev-cycle/artifacts.ts
+++ b/.pi/extensions/dev-cycle/artifacts.ts
@@ -1,0 +1,98 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { CycleRecord, ExecutionGraph } from "./types.js";
+
+function ensureDir(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function getRuntimeRoot(cwd: string): string {
+  return path.join(cwd, ".pi", "dev-cycles");
+}
+
+export function getCyclesDir(cwd: string): string {
+  return path.join(getRuntimeRoot(cwd), "cycles");
+}
+
+export function getGraphsDir(cwd: string): string {
+  return path.join(getRuntimeRoot(cwd), "graphs");
+}
+
+export function ensureRuntimeDirs(cwd: string): void {
+  ensureDir(getCyclesDir(cwd));
+  ensureDir(getGraphsDir(cwd));
+}
+
+export function ensureRuntimeGitignore(cwd: string): void {
+  const gitignorePath = path.join(cwd, ".gitignore");
+  const entry = ".pi/dev-cycles/";
+
+  if (!fs.existsSync(gitignorePath)) {
+    fs.writeFileSync(gitignorePath, `${entry}\n`, "utf-8");
+    return;
+  }
+
+  const current = fs.readFileSync(gitignorePath, "utf-8");
+  if (!current.includes(entry)) {
+    const next = current.endsWith("\n") ? `${current}${entry}\n` : `${current}\n${entry}\n`;
+    fs.writeFileSync(gitignorePath, next, "utf-8");
+  }
+}
+
+export function getCyclePath(cwd: string, slug: string): string {
+  return path.join(getCyclesDir(cwd), `${slug}.json`);
+}
+
+export function writeCycle(cwd: string, cycle: CycleRecord): string {
+  ensureRuntimeDirs(cwd);
+  const filePath = getCyclePath(cwd, cycle.slug);
+  fs.writeFileSync(filePath, JSON.stringify(cycle, null, 2), "utf-8");
+  return filePath;
+}
+
+export function readCycle(cwd: string, slug: string): CycleRecord | null {
+  const filePath = getCyclePath(cwd, slug);
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, "utf-8")) as CycleRecord;
+}
+
+export function listCycles(cwd: string): CycleRecord[] {
+  const dir = getCyclesDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+
+  return fs
+    .readdirSync(dir)
+    .filter((name) => name.endsWith(".json"))
+    .map((name) => {
+      const content = fs.readFileSync(path.join(dir, name), "utf-8");
+      return JSON.parse(content) as CycleRecord;
+    })
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export function getGraphPath(cwd: string, slug: string): string {
+  return path.join(getGraphsDir(cwd), `${slug}.json`);
+}
+
+export function writeGraph(cwd: string, slug: string, graph: ExecutionGraph): string {
+  ensureRuntimeDirs(cwd);
+  const filePath = getGraphPath(cwd, slug);
+  fs.writeFileSync(filePath, JSON.stringify(graph, null, 2), "utf-8");
+  return filePath;
+}
+
+export function readGraph(cwd: string, slug: string): ExecutionGraph | null {
+  const filePath = getGraphPath(cwd, slug);
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, "utf-8")) as ExecutionGraph;
+}
+
+export function writePlanFile(cwd: string, slug: string, markdown: string): string {
+  const dir = path.join(cwd, "plans");
+  ensureDir(dir);
+  const filePath = path.join(dir, `${slug}.md`);
+  fs.writeFileSync(filePath, markdown, "utf-8");
+  return filePath;
+}

--- a/.pi/extensions/dev-cycle/classify.test.ts
+++ b/.pi/extensions/dev-cycle/classify.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { classifyRequest, deriveCycleTitle, inferBranchType, normalizeUserStories, slugify } from "./classify.js";
+
+describe("classify", () => {
+  it("normalizes pipe and newline user stories", () => {
+    expect(normalizeUserStories("One\n- Two\n3. Three")).toEqual(["One", "Two", "Three"]);
+  });
+
+  it("infers fix branches for bug-shaped work", () => {
+    expect(inferBranchType("Fix regression in cycle-start command", [])).toBe("fix");
+  });
+
+  it("classifies tiny bugfixes as quickfix", () => {
+    const classification = classifyRequest({
+      problem: "Fix the typo in cycle status output",
+      userStories: [],
+      branchType: "fix",
+    });
+
+    expect(classification.route).toBe("quickfix");
+    expect(classification.requiredStages).toContain("implementation");
+    expect(classification.requiredStages).not.toContain("prd");
+  });
+
+  it("classifies multi-story work as planned", () => {
+    const classification = classifyRequest({
+      problem: "Build a dev cycle extension",
+      userStories: ["As a developer, I want planning.", "As a developer, I want implementation orchestration."],
+      branchType: "feat",
+    });
+
+    expect(classification.route).toBe("planned");
+    expect(classification.requiredStages).toContain("prd");
+    expect(classification.requiredStages).toContain("plan");
+  });
+
+  it("creates stable titles and slugs", () => {
+    expect(deriveCycleTitle("Build the Dev Cycle Pi Extension", [])).toBe("Build the Dev Cycle Pi Extension");
+    expect(slugify("Build the Dev Cycle Pi Extension")).toBe("build-the-dev-cycle-pi-extension");
+  });
+});

--- a/.pi/extensions/dev-cycle/classify.ts
+++ b/.pi/extensions/dev-cycle/classify.ts
@@ -1,0 +1,105 @@
+import type { BranchType, CycleClassification, CycleRequest, CycleRoute } from "./types.js";
+
+const BUG_KEYWORDS = [
+  "bug",
+  "fix",
+  "broken",
+  "error",
+  "regression",
+  "typo",
+  "crash",
+  "failing",
+];
+
+const CHORE_KEYWORDS = [
+  "config",
+  "rule",
+  "lint",
+  "dependency",
+  "deps",
+  "tooling",
+  "ci",
+  "docs",
+  "documentation",
+];
+
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60);
+}
+
+export function normalizeUserStories(value?: string | string[]): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.map((item) => item.trim()).filter(Boolean);
+  }
+
+  return value
+    .split(/\n+/)
+    .map((item) => item.replace(/^\s*[-*\d.]+\s*/, "").trim())
+    .filter(Boolean);
+}
+
+export function inferBranchType(problem: string, userStories: string[]): BranchType {
+  const text = `${problem}\n${userStories.join("\n")}`.toLowerCase();
+  if (BUG_KEYWORDS.some((keyword) => text.includes(keyword))) return "fix";
+  if (CHORE_KEYWORDS.some((keyword) => text.includes(keyword))) return "chore";
+  return "feat";
+}
+
+export function deriveCycleTitle(problem: string, userStories: string[]): string {
+  const base = problem.trim() || userStories[0] || "Untitled dev cycle";
+  return base.length > 72 ? `${base.slice(0, 69)}...` : base;
+}
+
+function detectRoute(request: CycleRequest): {
+  route: CycleRoute;
+  rationale: string;
+  confidence: "low" | "medium" | "high";
+} {
+  const text = `${request.problem}\n${request.userStories.join("\n")}`.trim();
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+  const storyCount = request.userStories.length;
+  const hasBugWords = BUG_KEYWORDS.some((keyword) => text.toLowerCase().includes(keyword));
+  const hasQuestionMark = text.includes("?");
+
+  if (storyCount <= 1 && wordCount <= 70 && hasBugWords && !hasQuestionMark) {
+    return {
+      route: "quickfix",
+      rationale: "Short, specific, bug-flavored request with little planning overhead.",
+      confidence: "high",
+    };
+  }
+
+  if (storyCount === 0 && wordCount <= 25 && hasBugWords) {
+    return {
+      route: "quickfix",
+      rationale: "Tiny fix request with no evidence of broader design work.",
+      confidence: "medium",
+    };
+  }
+
+  return {
+    route: "planned",
+    rationale: "Feature scope, multiple stories, or ambiguity indicates a full planning flow.",
+    confidence: storyCount > 1 || wordCount > 120 ? "high" : "medium",
+  };
+}
+
+export function classifyRequest(request: CycleRequest): CycleClassification {
+  const detected = detectRoute(request);
+  const requiredStages =
+    detected.route === "quickfix"
+      ? (["classify", "implementation", "verification", "closed"] as const)
+      : (["classify", "prd", "issues", "plan", "implementation", "verification", "closed"] as const);
+
+  return {
+    route: detected.route,
+    rationale: detected.rationale,
+    confidence: detected.confidence,
+    requiredStages: [...requiredStages],
+  };
+}

--- a/.pi/extensions/dev-cycle/github.ts
+++ b/.pi/extensions/dev-cycle/github.ts
@@ -1,0 +1,32 @@
+import { execFile } from "node:child_process";
+
+function execGh(args: string[], cwd: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    execFile("gh", args, { cwd }, (error, stdout, stderr) => {
+      resolve({
+        stdout,
+        stderr,
+        exitCode: error ? ((error as { code?: number }).code ?? 1) : 0,
+      });
+    });
+  });
+}
+
+export async function createGitHubIssue(
+  cwd: string,
+  title: string,
+  body: string,
+): Promise<{ number: number; url: string }> {
+  const result = await execGh(["issue", "create", "--title", title, "--body", body], cwd);
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || "gh issue create failed");
+  }
+
+  const url = result.stdout.trim();
+  const numberMatch = url.match(/\/issues\/(\d+)$/);
+  if (!numberMatch) {
+    throw new Error(`Could not parse issue number from ${url}`);
+  }
+
+  return { number: Number(numberMatch[1]), url };
+}

--- a/.pi/extensions/dev-cycle/graph.test.ts
+++ b/.pi/extensions/dev-cycle/graph.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { addNode, attachSubagentResults, createExecutionGraph, finishNode } from "./graph.js";
+
+describe("graph helpers", () => {
+  it("adds nodes and attaches nested subagent results", () => {
+    const graph = createExecutionGraph("demo", "Demo cycle");
+    const toolNode = addNode(graph, graph.rootId, "tool", "cycle_subagent", "running");
+    const childGraph = createExecutionGraph("child", "Child");
+    const nestedAgent = addNode(childGraph, childGraph.rootId, "agent", "Developer", "running");
+    finishNode(childGraph, nestedAgent, "completed", "Patched files");
+
+    attachSubagentResults(graph, toolNode, [
+      {
+        agent: "Developer",
+        source: "built-in",
+        task: "Implement the feature",
+        exitCode: 0,
+        output: "Done",
+        stderr: "",
+        usage: { input: 1, output: 1, cost: 0, turns: 1 },
+        graph: childGraph,
+      },
+    ]);
+
+    const labels = Object.values(graph.nodes).map((node) => node.label);
+    expect(labels).toContain("Developer");
+    expect(labels).toContain("cycle_subagent");
+  });
+});

--- a/.pi/extensions/dev-cycle/graph.ts
+++ b/.pi/extensions/dev-cycle/graph.ts
@@ -1,0 +1,123 @@
+import type { ExecutionGraph, ExecutionNode, ExecutionNodeKind, ExecutionNodeStatus, SubagentResult } from "./types.js";
+
+function newId(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+export function createExecutionGraph(cycleSlug: string, label: string): ExecutionGraph {
+  const rootId = newId("cycle");
+  return {
+    cycleSlug,
+    rootId,
+    updatedAt: now(),
+    nodes: {
+      [rootId]: {
+        id: rootId,
+        parentId: null,
+        kind: "cycle",
+        label,
+        status: "running",
+        startedAt: now(),
+        children: [],
+      },
+    },
+  };
+}
+
+export function addNode(
+  graph: ExecutionGraph,
+  parentId: string,
+  kind: ExecutionNodeKind,
+  label: string,
+  status: ExecutionNodeStatus = "queued",
+  metadata?: ExecutionNode["metadata"],
+): string {
+  const id = newId(kind);
+  graph.nodes[id] = {
+    id,
+    parentId,
+    kind,
+    label,
+    status,
+    startedAt: now(),
+    metadata,
+    children: [],
+  };
+  graph.nodes[parentId]?.children.push(id);
+  graph.updatedAt = now();
+  return id;
+}
+
+export function updateNode(
+  graph: ExecutionGraph,
+  nodeId: string,
+  patch: Partial<Omit<ExecutionNode, "id" | "parentId" | "children">>,
+): void {
+  const node = graph.nodes[nodeId];
+  if (!node) return;
+  Object.assign(node, patch);
+  graph.updatedAt = now();
+}
+
+export function finishNode(
+  graph: ExecutionGraph,
+  nodeId: string,
+  status: ExecutionNodeStatus,
+  detail?: string,
+): void {
+  const node = graph.nodes[nodeId];
+  if (!node) return;
+  node.status = status;
+  node.endedAt = now();
+  if (detail) node.detail = detail;
+  graph.updatedAt = now();
+}
+
+export function attachSubagentResults(
+  graph: ExecutionGraph,
+  parentToolNodeId: string,
+  results: SubagentResult[],
+): void {
+  for (const result of results) {
+    const agentNodeId = addNode(
+      graph,
+      parentToolNodeId,
+      "agent",
+      result.agent,
+      result.exitCode === 0 ? "completed" : "failed",
+      {
+        source: result.source,
+        cost: result.usage.cost,
+        turns: result.usage.turns,
+      },
+    );
+    updateNode(graph, agentNodeId, {
+      detail: result.output || result.stderr || "(no output)",
+    });
+
+    if (result.graph) {
+      for (const childId of result.graph.nodes[result.graph.rootId]?.children ?? []) {
+        cloneNodeTree(result.graph, graph, childId, agentNodeId);
+      }
+    }
+  }
+}
+
+function cloneNodeTree(source: ExecutionGraph, target: ExecutionGraph, sourceNodeId: string, parentId: string): void {
+  const sourceNode = source.nodes[sourceNodeId];
+  if (!sourceNode) return;
+  const clonedId = addNode(target, parentId, sourceNode.kind, sourceNode.label, sourceNode.status, sourceNode.metadata);
+  updateNode(target, clonedId, {
+    detail: sourceNode.detail,
+    startedAt: sourceNode.startedAt,
+    endedAt: sourceNode.endedAt,
+  });
+
+  for (const childId of sourceNode.children) {
+    cloneNodeTree(source, target, childId, clonedId);
+  }
+}

--- a/.pi/extensions/dev-cycle/index.ts
+++ b/.pi/extensions/dev-cycle/index.ts
@@ -1,0 +1,639 @@
+import * as path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { StringEnum } from "@mariozechner/pi-ai";
+import { Type } from "@sinclair/typebox";
+import { Text } from "@mariozechner/pi-tui";
+import { discoverTeamAgents, selectImplementationOrchestrator, summarizeAgents } from "./agents.js";
+import {
+  ensureRuntimeDirs,
+  ensureRuntimeGitignore,
+  listCycles,
+  readCycle,
+  readGraph,
+  writeCycle,
+  writeGraph,
+  writePlanFile,
+} from "./artifacts.js";
+import { addNode, createExecutionGraph, finishNode } from "./graph.js";
+import { createGitHubIssue } from "./github.js";
+import { runPiTask } from "./pi-runner.js";
+import { execCommand } from "./shell.js";
+import {
+  approveStage,
+  createCycleRecord,
+  determineCurrentStage,
+  markImplementationFinished,
+  markImplementationStarted,
+  markVerificationFinished,
+  runIssueStage,
+  runPlanStage,
+  runPrdStage,
+  touchCycle,
+} from "./stages.js";
+import type {
+  BranchType,
+  CycleRecord,
+  CycleStageKey,
+  ExecutionGraph,
+  PiRunOptions,
+  SubagentResult,
+  SubagentTask,
+  UsageTotals,
+} from "./types.js";
+import { buildPlainStatusLines, buildStatusLine, buildWidgetLines } from "./ui.js";
+import { getCycleBranchName, getCycleWorktreePath, ensureCycleWorktree } from "./worktree.js";
+
+const BRANCH_TYPE = StringEnum(["feat", "fix", "chore"] as const, { description: "Branch prefix for the implementation worktree" });
+const APPROVAL_STAGE = StringEnum(["prd", "issues", "plan"] as const, { description: "Which planning artifact to approve" });
+const ACTION = StringEnum(["start", "next", "status", "approve", "implement", "list", "resume"] as const, {
+  description: "Dev-cycle action",
+});
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function parseQuotedFlag(input: string, flag: string): string | undefined {
+  const match = input.match(new RegExp(`${flag}\\s+\"([^\"]+)\"`));
+  return match?.[1];
+}
+
+function parseWordFlag(input: string, flag: string): string | undefined {
+  const match = input.match(new RegExp(`${flag}\\s+(\\S+)`));
+  return match?.[1];
+}
+
+function stripFlags(input: string): string {
+  return input
+    .replace(/--slug\s+\S+/g, "")
+    .replace(/--branch-type\s+\S+/g, "")
+    .replace(/--stories\s+"[^"]+"/g, "")
+    .trim();
+}
+
+function parseUserStories(raw?: string): string[] {
+  if (!raw) return [];
+  return raw.split("|").map((item) => item.trim()).filter(Boolean);
+}
+
+function currentCycle(cwd: string, activeCycleSlug: string | null, requestedSlug?: string): CycleRecord | null {
+  if (requestedSlug) return readCycle(cwd, requestedSlug);
+  if (activeCycleSlug) {
+    const active = readCycle(cwd, activeCycleSlug);
+    if (active) return active;
+  }
+
+  return listCycles(cwd).find((cycle) => cycle.currentStage !== "closed") ?? listCycles(cwd)[0] ?? null;
+}
+
+function persistCycle(cycle: CycleRecord, graph: ExecutionGraph | null): void {
+  writeCycle(cycle.cwd, cycle);
+  if (graph) {
+    cycle.artifacts.executionGraphPath = writeGraph(cycle.cwd, cycle.slug, graph);
+    writeCycle(cycle.cwd, cycle);
+  }
+}
+
+function cycleGraph(cycle: CycleRecord): ExecutionGraph {
+  return readGraph(cycle.cwd, cycle.slug) ?? createExecutionGraph(cycle.slug, cycle.title);
+}
+
+function setCycleUi(ctx: any, cycle: CycleRecord, graph: ExecutionGraph | null): void {
+  ctx.ui.setStatus("dev-cycle", buildStatusLine(cycle));
+  if (ctx.hasUI) {
+    ctx.ui.setWidget("dev-cycle", buildWidgetLines(cycle, graph, ctx.ui.theme));
+  }
+}
+
+async function runTrackedTask(
+  cycle: CycleRecord,
+  graph: ExecutionGraph,
+  stageLabel: string,
+  nodeLabel: string,
+  options: Omit<PiRunOptions, "graph" | "parentNodeId" | "nodeLabel" | "onGraphUpdate">,
+  onGraphUpdate: (graph: ExecutionGraph) => void,
+): Promise<string> {
+  const stageNodeId = addNode(graph, graph.rootId, "stage", stageLabel, "running");
+  onGraphUpdate(graph);
+
+  const result = await runPiTask({
+    ...options,
+    graph,
+    parentNodeId: stageNodeId,
+    nodeLabel,
+    onGraphUpdate,
+  });
+
+  finishNode(
+    graph,
+    stageNodeId,
+    result.exitCode === 0 ? "completed" : "failed",
+    result.output || result.stderr || result.errorMessage,
+  );
+  onGraphUpdate(graph);
+
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || result.errorMessage || `${stageLabel} failed`);
+  }
+
+  return result.output;
+}
+
+function buildPlanningSystemPrompt(): string {
+  return [
+    "You are a staff-level planning agent.",
+    "Follow output instructions exactly.",
+    "Do not add commentary outside the requested format.",
+  ].join("\n");
+}
+
+function buildImplementationSystemPrompt(orchestratorPrompt: string, teamSummary: string): string {
+  return [
+    orchestratorPrompt,
+    "",
+    "The plan is already approved. Treat planning approval as satisfied and execute now.",
+    "Use the cycle_subagent tool for delegation instead of any other subagent mechanism.",
+    `Available team: ${teamSummary}`,
+    "Stay inside the current worktree cwd for all code changes.",
+    "Finish with a concise implementation summary and verification notes.",
+  ].join("\n");
+}
+
+function buildImplementationTask(cycle: CycleRecord): string {
+  const slices = (cycle.artifacts.slices ?? [])
+    .map((slice) => `- ${slice.title}${slice.issueNumber ? ` (#${slice.issueNumber})` : ""}`)
+    .join("\n");
+
+  return [
+    `Problem: ${cycle.request.problem}`,
+    cycle.request.userStories.length > 0
+      ? `User stories:\n${cycle.request.userStories.map((story, index) => `${index + 1}. ${story}`).join("\n")}`
+      : "User stories: none",
+    cycle.artifacts.prdIssueUrl ? `PRD issue: ${cycle.artifacts.prdIssueUrl}` : "",
+    cycle.artifacts.planPath ? `Approved plan path: ${cycle.artifacts.planPath}` : "",
+    cycle.artifacts.planMarkdown ? `Approved plan markdown:\n${cycle.artifacts.planMarkdown}` : "",
+    slices ? `Slice issues:\n${slices}` : "",
+    "",
+    "Implement the approved work in this worktree. Delegate to the appropriate specialists with cycle_subagent.",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function buildVerificationTask(cycle: CycleRecord): string {
+  return [
+    `Verify the implementation for cycle ${cycle.slug}.`,
+    cycle.artifacts.planMarkdown ? `Approved plan:\n${cycle.artifacts.planMarkdown}` : "",
+    cycle.artifacts.implementationSummary ? `Implementation summary:\n${cycle.artifacts.implementationSummary}` : "",
+    "Return a concise verification summary with what was verified, what remains uncertain, and any risk notes.",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+async function advancePlanning(cycle: CycleRecord, ctx: any): Promise<CycleRecord> {
+  const graph = cycleGraph(cycle);
+  const onGraphUpdate = (nextGraph: ExecutionGraph) => {
+    persistCycle(cycle, nextGraph);
+    setCycleUi(ctx, cycle, nextGraph);
+  };
+
+  while (true) {
+    cycle.currentStage = determineCurrentStage(cycle);
+    setCycleUi(ctx, cycle, graph);
+
+    if (cycle.currentStage === "prd" && !cycle.approvals.prd) {
+      if (cycle.stages.prd.status === "awaiting_approval") break;
+      await runPrdStage(
+        cycle,
+        (prompt) =>
+          runTrackedTask(
+            cycle,
+            graph,
+            "PRD stage",
+            "PRD planner",
+            { cwd: cycle.cwd, systemPrompt: buildPlanningSystemPrompt(), task: prompt, allowExtensions: false },
+            onGraphUpdate,
+          ),
+        (title, body) => createGitHubIssue(cycle.cwd, title, body),
+      );
+      persistCycle(cycle, graph);
+      break;
+    }
+
+    if (cycle.currentStage === "issues" && !cycle.approvals.issues) {
+      if (cycle.stages.issues.status === "awaiting_approval") break;
+      await runIssueStage(
+        cycle,
+        (prompt) =>
+          runTrackedTask(
+            cycle,
+            graph,
+            "Issue slicing stage",
+            "Issue planner",
+            { cwd: cycle.cwd, systemPrompt: buildPlanningSystemPrompt(), task: prompt, allowExtensions: false },
+            onGraphUpdate,
+          ),
+        (title, body) => createGitHubIssue(cycle.cwd, title, body),
+      );
+      persistCycle(cycle, graph);
+      break;
+    }
+
+    if (cycle.currentStage === "plan" && !cycle.approvals.plan) {
+      if (cycle.stages.plan.status === "awaiting_approval") break;
+      await runPlanStage(
+        cycle,
+        (prompt) =>
+          runTrackedTask(
+            cycle,
+            graph,
+            "Plan stage",
+            "Plan writer",
+            { cwd: cycle.cwd, systemPrompt: buildPlanningSystemPrompt(), task: prompt, allowExtensions: false },
+            onGraphUpdate,
+          ),
+        (markdown) => writePlanFile(cycle.cwd, cycle.slug, markdown),
+      );
+      persistCycle(cycle, graph);
+      break;
+    }
+
+    break;
+  }
+
+  cycle.currentStage = determineCurrentStage(cycle);
+  persistCycle(cycle, graph);
+  return cycle;
+}
+
+async function runImplementation(cycle: CycleRecord, ctx: any): Promise<CycleRecord> {
+  if (cycle.classification.route === "planned" && !(cycle.approvals.prd && cycle.approvals.issues && cycle.approvals.plan)) {
+    throw new Error("Implementation is blocked until PRD, issues, and plan are all approved.");
+  }
+
+  const worktree = await ensureCycleWorktree(cycle.cwd, cycle.slug, cycle.request.branchType, execCommand);
+  cycle.artifacts.worktreePath = worktree.path;
+  cycle.artifacts.branchName = worktree.branch;
+  markImplementationStarted(cycle);
+
+  const graph = cycleGraph(cycle);
+  const onGraphUpdate = (nextGraph: ExecutionGraph) => {
+    persistCycle(cycle, nextGraph);
+    setCycleUi(ctx, cycle, nextGraph);
+  };
+
+  const agents = discoverTeamAgents(worktree.path);
+  const orchestrator = selectImplementationOrchestrator(agents);
+  if (!orchestrator) {
+    throw new Error("No implementation orchestrator agent found.");
+  }
+
+  const implementationOutput = await runTrackedTask(
+    cycle,
+    graph,
+    "Implementation stage",
+    orchestrator.name,
+    {
+      cwd: worktree.path,
+      systemPrompt: buildImplementationSystemPrompt(orchestrator.systemPrompt, summarizeAgents(agents)),
+      task: buildImplementationTask(cycle),
+      allowExtensions: true,
+      model: orchestrator.model,
+      tools: orchestrator.tools,
+      env: { DEV_CYCLE_SUBAGENT_DEPTH: "0" },
+    },
+    onGraphUpdate,
+  );
+  markImplementationFinished(cycle, implementationOutput);
+  persistCycle(cycle, graph);
+
+  cycle.stages.verification = { status: "running", startedAt: now() };
+  const verifier =
+    agents.find((agent) => agent.name === "Review & QA Orchestrator")
+    ?? agents.find((agent) => agent.name === "Verifier")
+    ?? agents.find((agent) => agent.name === "Developer");
+  if (!verifier) {
+    throw new Error("No verifier-style agent found.");
+  }
+
+  const verificationOutput = await runTrackedTask(
+    cycle,
+    graph,
+    "Verification stage",
+    verifier.name,
+    {
+      cwd: worktree.path,
+      systemPrompt: buildImplementationSystemPrompt(verifier.systemPrompt, summarizeAgents(agents)),
+      task: buildVerificationTask(cycle),
+      allowExtensions: true,
+      model: verifier.model,
+      tools: verifier.tools,
+      env: { DEV_CYCLE_SUBAGENT_DEPTH: "0" },
+    },
+    onGraphUpdate,
+  );
+  markVerificationFinished(cycle, verificationOutput);
+  persistCycle(cycle, graph);
+  return cycle;
+}
+
+function formatCycleList(cycles: CycleRecord[]): string {
+  if (cycles.length === 0) return "No dev cycles found.";
+  return cycles
+    .map((cycle) => `${cycle.slug} | ${cycle.currentStage} | ${cycle.classification.route} | ${cycle.updatedAt.slice(0, 10)}`)
+    .join("\n");
+}
+
+async function runSubagentTask(
+  cwd: string,
+  task: SubagentTask,
+  signal: AbortSignal | undefined,
+): Promise<SubagentResult> {
+  const agents = discoverTeamAgents(cwd);
+  const agent = agents.find((item) => item.name === task.agent || item.slug === task.agent);
+  if (!agent) {
+    return {
+      agent: task.agent,
+      source: "unknown",
+      task: task.task,
+      exitCode: 1,
+      output: "",
+      stderr: `Unknown agent: ${task.agent}`,
+      usage: { input: 0, output: 0, cost: 0, turns: 0 },
+    };
+  }
+
+  const currentDepth = Number(process.env.DEV_CYCLE_SUBAGENT_DEPTH || "0");
+  if (currentDepth >= 3) {
+    return {
+      agent: agent.name,
+      source: agent.source,
+      task: task.task,
+      exitCode: 1,
+      output: "",
+      stderr: "Maximum cycle_subagent depth reached.",
+      usage: { input: 0, output: 0, cost: 0, turns: 0 },
+      model: agent.model,
+    };
+  }
+
+  const graph = createExecutionGraph(agent.slug, agent.name);
+  const result = await runPiTask({
+    cwd: task.cwd ?? cwd,
+    systemPrompt: agent.systemPrompt,
+    task: task.task,
+    allowExtensions: true,
+    model: agent.model,
+    tools: agent.tools,
+    signal,
+    graph,
+    nodeLabel: agent.name,
+    env: { DEV_CYCLE_SUBAGENT_DEPTH: String(currentDepth + 1) },
+  });
+
+  return {
+    agent: agent.name,
+    source: agent.source,
+    task: task.task,
+    exitCode: result.exitCode,
+    output: result.output,
+    stderr: result.stderr,
+    usage: result.usage,
+    model: agent.model,
+    graph: result.graph,
+  };
+}
+
+export default function (pi: ExtensionAPI) {
+  let activeCycleSlug: string | null = null;
+
+  const devCycleParams = Type.Object({
+    action: ACTION,
+    slug: Type.Optional(Type.String()),
+    problem: Type.Optional(Type.String()),
+    branchType: Type.Optional(BRANCH_TYPE),
+    userStories: Type.Optional(Type.Array(Type.String())),
+    approve: Type.Optional(APPROVAL_STAGE),
+  });
+
+  async function handleAction(input: {
+    action: "start" | "next" | "status" | "approve" | "implement" | "list" | "resume";
+    slug?: string;
+    problem?: string;
+    branchType?: BranchType;
+    userStories?: string[];
+    approve?: "prd" | "issues" | "plan";
+  }, ctx: any): Promise<string> {
+    ensureRuntimeDirs(ctx.cwd);
+    ensureRuntimeGitignore(ctx.cwd);
+
+    if (input.action === "list") {
+      return formatCycleList(listCycles(ctx.cwd));
+    }
+
+    if (input.action === "start") {
+      if (!input.problem) throw new Error("A problem statement is required to start a cycle.");
+      let cycle = createCycleRecord(ctx.cwd, input.problem, input.userStories, input.branchType, input.slug);
+      activeCycleSlug = cycle.slug;
+      const graph = createExecutionGraph(cycle.slug, cycle.title);
+      persistCycle(cycle, graph);
+      cycle = await advancePlanning(cycle, ctx);
+      return `Started cycle ${cycle.slug}. Current stage: ${cycle.currentStage}.`;
+    }
+
+    const cycle = currentCycle(ctx.cwd, activeCycleSlug, input.slug);
+    if (!cycle) throw new Error("No dev cycle found.");
+    activeCycleSlug = cycle.slug;
+
+    if (input.action === "resume" || input.action === "status") {
+      const graph = readGraph(ctx.cwd, cycle.slug);
+      setCycleUi(ctx, cycle, graph);
+      return buildPlainStatusLines(cycle, graph).join("\n");
+    }
+
+    if (input.action === "approve") {
+      if (!input.approve) throw new Error("Choose prd, issues, or plan to approve.");
+      approveStage(cycle, input.approve);
+      await advancePlanning(cycle, ctx);
+      return `Approved ${input.approve} for ${cycle.slug}. Current stage: ${cycle.currentStage}.`;
+    }
+
+    if (input.action === "next") {
+      await advancePlanning(cycle, ctx);
+      return `Advanced ${cycle.slug}. Current stage: ${cycle.currentStage}.`;
+    }
+
+    if (input.action === "implement") {
+      const updated = await runImplementation(cycle, ctx);
+      return `Implementation complete for ${updated.slug}.\n\n${updated.artifacts.verificationSummary ?? updated.artifacts.implementationSummary ?? "No summary available."}`;
+    }
+
+    throw new Error(`Unknown action ${input.action}`);
+  }
+
+  pi.registerCommand("cycle-start", {
+    description: "Start a dev cycle from a problem statement",
+    handler: async (args, ctx) => {
+      const slug = parseWordFlag(args ?? "", "--slug");
+      const branchType = parseWordFlag(args ?? "", "--branch-type") as BranchType | undefined;
+      const stories = parseQuotedFlag(args ?? "", "--stories");
+      const problem = stripFlags(args ?? "");
+      const message = await handleAction(
+        { action: "start", slug, branchType, problem, userStories: parseUserStories(stories) },
+        ctx,
+      );
+      ctx.ui.notify(message, "info");
+    },
+  });
+
+  pi.registerCommand("cycle-next", {
+    description: "Run the next non-approved planning step for the active cycle",
+    handler: async (args, ctx) => {
+      const slug = (args ?? "").trim() || undefined;
+      const message = await handleAction({ action: "next", slug }, ctx);
+      ctx.ui.notify(message, "info");
+    },
+  });
+
+  pi.registerCommand("cycle-approve", {
+    description: "Approve prd, issues, or plan for the active cycle",
+    handler: async (args, ctx) => {
+      const [stage, slug] = (args ?? "").trim().split(/\s+/, 2);
+      const message = await handleAction({ action: "approve", approve: stage as any, slug }, ctx);
+      ctx.ui.notify(message, "info");
+    },
+  });
+
+  pi.registerCommand("cycle-implement", {
+    description: "Explicitly start implementation for the active cycle",
+    handler: async (args, ctx) => {
+      const slug = (args ?? "").trim() || undefined;
+      const message = await handleAction({ action: "implement", slug }, ctx);
+      ctx.ui.notify(message, "info");
+    },
+  });
+
+  pi.registerCommand("cycle-status", {
+    description: "Show status for the active dev cycle",
+    handler: async (args, ctx) => {
+      const slug = (args ?? "").trim() || undefined;
+      const message = await handleAction({ action: "status", slug }, ctx);
+      ctx.ui.notify(message, "info");
+    },
+  });
+
+  pi.registerCommand("cycle-list", {
+    description: "List saved dev cycles",
+    handler: async (_args, ctx) => {
+      const message = await handleAction({ action: "list" }, ctx);
+      ctx.ui.notify(message, "info");
+    },
+  });
+
+  pi.registerTool({
+    name: "dev_cycle",
+    label: "Dev Cycle",
+    description: "Manage a resumable development cycle from intake through planning, implementation, and verification.",
+    promptSnippet: "Start, advance, approve, inspect, or implement a dev cycle",
+    parameters: devCycleParams,
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const text = await handleAction(params as any, ctx);
+      return { content: [{ type: "text", text }] };
+    },
+    renderCall(args, theme) {
+      return new Text(
+        `${theme.fg("toolTitle", theme.bold("dev_cycle "))}${theme.fg("accent", args.action)}${args.slug ? theme.fg("muted", ` ${args.slug}`) : ""}`,
+        0,
+        0,
+      );
+    },
+    renderResult(result, _options, theme) {
+      const text = result.content[0];
+      return new Text(text?.type === "text" ? text.text : theme.fg("muted", "(no output)"), 0, 0);
+    },
+  });
+
+  pi.registerTool({
+    name: "cycle_subagent",
+    label: "Cycle Subagent",
+    description: "Delegate tasks to repo, project, or user agents with isolated Pi subprocesses and return structured results.",
+    promptSnippet: "Delegate implementation or verification work to a specialist agent",
+    parameters: Type.Object({
+      agent: Type.Optional(Type.String()),
+      task: Type.Optional(Type.String()),
+      tasks: Type.Optional(Type.Array(Type.Object({ agent: Type.String(), task: Type.String(), cwd: Type.Optional(Type.String()) }))),
+      chain: Type.Optional(Type.Array(Type.Object({ agent: Type.String(), task: Type.String(), cwd: Type.Optional(Type.String()) }))),
+    }),
+    async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      const hasSingle = Boolean(params.agent && params.task);
+      const hasParallel = (params.tasks?.length ?? 0) > 0;
+      const hasChain = (params.chain?.length ?? 0) > 0;
+      const modeCount = Number(hasSingle) + Number(hasParallel) + Number(hasChain);
+      if (modeCount !== 1) {
+        return {
+          content: [{ type: "text", text: "Provide exactly one mode: single, tasks, or chain." }],
+          details: { results: [] },
+          isError: true,
+        };
+      }
+
+      const update = (results: SubagentResult[]) => {
+        onUpdate?.({
+          content: [{ type: "text", text: results.map((item) => `[${item.agent}] ${item.exitCode === 0 ? "ok" : "failed"}`).join("\n") || "(running...)" }],
+          details: { results },
+        });
+      };
+
+      if (hasSingle) {
+        const result = await runSubagentTask(ctx.cwd, { agent: params.agent!, task: params.task! }, signal);
+        update([result]);
+        return {
+          content: [{ type: "text", text: result.output || result.stderr || "(no output)" }],
+          details: { results: [result] },
+          isError: result.exitCode !== 0,
+        };
+      }
+
+      if (hasParallel) {
+        const results = await Promise.all((params.tasks ?? []).map((task) => runSubagentTask(ctx.cwd, task, signal)));
+        update(results);
+        return {
+          content: [{ type: "text", text: results.map((item) => `[${item.agent}] ${item.output || item.stderr || "(no output)"}`).join("\n\n") }],
+          details: { results },
+          isError: results.some((item) => item.exitCode !== 0),
+        };
+      }
+
+      const results: SubagentResult[] = [];
+      let previous = "";
+      for (const step of params.chain ?? []) {
+        const task = step.task.replace(/\{previous\}/g, previous);
+        const result = await runSubagentTask(ctx.cwd, { agent: step.agent, task, cwd: step.cwd }, signal);
+        results.push(result);
+        update(results);
+        if (result.exitCode !== 0) {
+          return {
+            content: [{ type: "text", text: result.stderr || result.output || "Chain failed." }],
+            details: { results },
+            isError: true,
+          };
+        }
+        previous = result.output;
+      }
+
+      return {
+        content: [{ type: "text", text: results[results.length - 1]?.output || "(no output)" }],
+        details: { results },
+      };
+    },
+    renderCall(args, theme) {
+      const label = args.agent ? args.agent : args.tasks ? `parallel(${args.tasks.length})` : `chain(${args.chain?.length ?? 0})`;
+      return new Text(`${theme.fg("toolTitle", theme.bold("cycle_subagent "))}${theme.fg("accent", label)}`, 0, 0);
+    },
+    renderResult(result, _options, theme) {
+      const text = result.content[0];
+      return new Text(text?.type === "text" ? text.text : theme.fg("muted", "(no output)"), 0, 0);
+    },
+  });
+}

--- a/.pi/extensions/dev-cycle/package-lock.json
+++ b/.pi/extensions/dev-cycle/package-lock.json
@@ -1,0 +1,1251 @@
+{
+  "name": "dev-cycle",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dev-cycle",
+      "version": "0.1.0",
+      "devDependencies": {
+        "vitest": "^4.1.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
+      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
+      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.11"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
+      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.11",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.1",
+        "@vitest/mocker": "4.1.1",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/runner": "4.1.1",
+        "@vitest/snapshot": "4.1.1",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.1",
+        "@vitest/browser-preview": "4.1.1",
+        "@vitest/browser-webdriverio": "4.1.1",
+        "@vitest/ui": "4.1.1",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/.pi/extensions/dev-cycle/package.json
+++ b/.pi/extensions/dev-cycle/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dev-cycle",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "devDependencies": {
+    "vitest": "^4.1.1"
+  }
+}

--- a/.pi/extensions/dev-cycle/pi-runner.ts
+++ b/.pi/extensions/dev-cycle/pi-runner.ts
@@ -1,0 +1,221 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { addNode, attachSubagentResults, createExecutionGraph, finishNode, updateNode } from "./graph.js";
+import type { PiRunOptions, PiRunResult, SubagentResult, UsageTotals } from "./types.js";
+
+function getPiInvocation(args: string[]): { command: string; args: string[] } {
+  const currentScript = process.argv[1];
+  if (currentScript && fs.existsSync(currentScript)) {
+    return { command: process.execPath, args: [currentScript, ...args] };
+  }
+
+  const execName = path.basename(process.execPath).toLowerCase();
+  if (!/^(node|bun)(\.exe)?$/.test(execName)) {
+    return { command: process.execPath, args };
+  }
+
+  return { command: "pi", args };
+}
+
+async function writePromptFile(prompt: string, label: string): Promise<{ dir: string; filePath: string }> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "dev-cycle-"));
+  const filePath = path.join(dir, `${label}.md`);
+  await fs.promises.writeFile(filePath, prompt, { encoding: "utf-8", mode: 0o600 });
+  return { dir, filePath };
+}
+
+function previewFromContent(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const textPart = content.find(
+    (item): item is { type: string; text?: string } =>
+      !!item && typeof item === "object" && (item as { type?: string }).type === "text",
+  );
+  return textPart?.text;
+}
+
+export async function runPiTask(options: PiRunOptions): Promise<PiRunResult> {
+  const graph = options.graph ?? createExecutionGraph("adhoc", options.nodeLabel ?? "Pi task");
+  const parentNodeId = options.parentNodeId ?? graph.rootId;
+  const rootNodeId = addNode(graph, parentNodeId, "agent", options.nodeLabel ?? "Pi task", "running");
+  options.onGraphUpdate?.(graph);
+
+  const args: string[] = ["--mode", "json", "-p", "--no-session"];
+  if (!options.allowExtensions) args.unshift("--no-extensions");
+  if (options.model) args.push("--model", options.model);
+  if (options.tools && options.tools.length > 0) args.push("--tools", options.tools.join(","));
+
+  let tmpDir: string | null = null;
+  let tmpPath: string | null = null;
+
+  const usage: UsageTotals = { input: 0, output: 0, cost: 0, turns: 0 };
+  let finalOutput = "";
+  let stderr = "";
+  let stopReason: string | undefined;
+  let errorMessage: string | undefined;
+
+  try {
+    if (options.systemPrompt.trim()) {
+      const promptFile = await writePromptFile(options.systemPrompt, "system-prompt");
+      tmpDir = promptFile.dir;
+      tmpPath = promptFile.filePath;
+      args.push("--append-system-prompt", promptFile.filePath);
+    }
+
+    args.push(`Task: ${options.task}`);
+
+    const toolNodes = new Map<string, string>();
+    let buffer = "";
+    let aborted = false;
+
+    const exitCode = await new Promise<number>((resolve) => {
+      const invocation = getPiInvocation(args);
+      const proc = spawn(invocation.command, invocation.args, {
+        cwd: options.cwd,
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env, ...options.env },
+      });
+
+      const processLine = (line: string) => {
+        if (!line.trim()) return;
+
+        let event: any;
+        try {
+          event = JSON.parse(line);
+        } catch {
+          return;
+        }
+
+        if (event.type === "message_update" && event.assistantMessageEvent?.type === "text_delta") {
+          finalOutput += event.assistantMessageEvent.delta;
+          updateNode(graph, rootNodeId, { detail: finalOutput.slice(-400) });
+          options.onGraphUpdate?.(graph);
+          return;
+        }
+
+        if (event.type === "tool_execution_start") {
+          const label = `${event.toolName}`;
+          const detail = JSON.stringify(event.args ?? {});
+          const nodeId = addNode(graph, rootNodeId, "tool", label, "running", {
+            toolCallId: event.toolCallId,
+          });
+          updateNode(graph, nodeId, { detail });
+          toolNodes.set(event.toolCallId, nodeId);
+          options.onGraphUpdate?.(graph);
+          return;
+        }
+
+        if (event.type === "tool_execution_update") {
+          const nodeId = toolNodes.get(event.toolCallId);
+          if (!nodeId) return;
+          const preview = previewFromContent(event.partialResult?.content);
+          if (preview) updateNode(graph, nodeId, { detail: preview.slice(0, 400) });
+          options.onGraphUpdate?.(graph);
+          return;
+        }
+
+        if (event.type === "tool_execution_end") {
+          const nodeId = toolNodes.get(event.toolCallId);
+          if (!nodeId) return;
+          const preview = previewFromContent(event.result?.content) ?? JSON.stringify(event.result?.details ?? {});
+          finishNode(graph, nodeId, event.result?.isError ? "failed" : "completed", preview.slice(0, 400));
+
+          const details = event.result?.details as { results?: SubagentResult[] } | undefined;
+          if (details?.results && Array.isArray(details.results)) {
+            attachSubagentResults(graph, nodeId, details.results);
+          }
+
+          options.onGraphUpdate?.(graph);
+          return;
+        }
+
+        if (event.type === "message_end" && event.message?.role === "assistant") {
+          for (const part of event.message.content ?? []) {
+            if (part.type === "text") finalOutput = part.text;
+          }
+
+          if (event.message.usage) {
+            usage.input += event.message.usage.input || 0;
+            usage.output += event.message.usage.output || 0;
+            usage.cost += event.message.usage.cost?.total || 0;
+          }
+          usage.turns += 1;
+          stopReason = event.message.stopReason;
+          errorMessage = event.message.errorMessage;
+          updateNode(graph, rootNodeId, { detail: finalOutput.slice(-400) });
+          options.onGraphUpdate?.(graph);
+        }
+      };
+
+      proc.stdout.on("data", (chunk: Buffer) => {
+        buffer += chunk.toString();
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+        for (const line of lines) processLine(line);
+      });
+
+      proc.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      proc.on("close", (code) => {
+        if (buffer.trim()) processLine(buffer);
+        resolve(code ?? 0);
+      });
+
+      proc.on("error", () => resolve(1));
+
+      if (options.signal) {
+        const killProc = () => {
+          aborted = true;
+          proc.kill("SIGTERM");
+          setTimeout(() => {
+            if (!proc.killed) proc.kill("SIGKILL");
+          }, 5000);
+        };
+
+        if (options.signal.aborted) killProc();
+        else options.signal.addEventListener("abort", killProc, { once: true });
+      }
+    });
+
+    finishNode(
+      graph,
+      rootNodeId,
+      aborted ? "aborted" : exitCode === 0 ? "completed" : "failed",
+      finalOutput || stderr || errorMessage,
+    );
+    if (rootNodeId === graph.rootId) {
+      finishNode(graph, graph.rootId, aborted ? "aborted" : exitCode === 0 ? "completed" : "failed");
+    }
+    options.onGraphUpdate?.(graph);
+
+    return {
+      exitCode,
+      output: finalOutput,
+      stderr,
+      stopReason,
+      errorMessage,
+      usage,
+      rootNodeId,
+      graph,
+    };
+  } catch (error: any) {
+    finishNode(graph, rootNodeId, "failed", error.message ?? "Unknown error");
+    options.onGraphUpdate?.(graph);
+    return {
+      exitCode: 1,
+      output: "",
+      stderr: error.message ?? "Unknown error",
+      usage,
+      rootNodeId,
+      graph,
+      errorMessage: error.message ?? "Unknown error",
+    };
+  } finally {
+    if (tmpPath) try { fs.unlinkSync(tmpPath); } catch {}
+    if (tmpDir) try { fs.rmdirSync(tmpDir); } catch {}
+  }
+}

--- a/.pi/extensions/dev-cycle/shell.ts
+++ b/.pi/extensions/dev-cycle/shell.ts
@@ -1,0 +1,14 @@
+import { execFile } from "node:child_process";
+import type { ExecLikeResult } from "./worktree.js";
+
+export function execCommand(command: string, args: string[], cwd: string): Promise<ExecLikeResult> {
+  return new Promise((resolve) => {
+    execFile(command, args, { cwd }, (error, stdout, stderr) => {
+      resolve({
+        stdout,
+        stderr,
+        exitCode: error ? ((error as { code?: number }).code ?? 1) : 0,
+      });
+    });
+  });
+}

--- a/.pi/extensions/dev-cycle/smoke-temp.ts
+++ b/.pi/extensions/dev-cycle/smoke-temp.ts
@@ -1,0 +1,58 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { writeCycle, readCycle, writeGraph, readGraph } from "./artifacts.js";
+import { createExecutionGraph, addNode, finishNode } from "./graph.js";
+import { createCycleRecord, approveStage, determineCurrentStage } from "./stages.js";
+import { buildPlainStatusLines } from "./ui.js";
+import { ensureCycleWorktree, getCycleBranchName, getCycleWorktreePath } from "./worktree.js";
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-cycle-smoke-"));
+
+try {
+  const cycle = createCycleRecord(
+    tempDir,
+    "Build a generic dev-cycle extension",
+    [
+      "As a developer, I want the workflow to be resumable.",
+      "As a developer, I want an explicit implementation trigger.",
+    ],
+  );
+
+  approveStage(cycle, "prd");
+  approveStage(cycle, "issues");
+  approveStage(cycle, "plan");
+
+  if (determineCurrentStage(cycle) !== "implementation") {
+    throw new Error(`Expected implementation stage, got ${determineCurrentStage(cycle)}`);
+  }
+
+  writeCycle(tempDir, cycle);
+  const graph = createExecutionGraph(cycle.slug, cycle.title);
+  const stageId = addNode(graph, graph.rootId, "stage", "Implementation stage", "running");
+  const toolId = addNode(graph, stageId, "tool", "cycle_subagent", "running");
+  finishNode(graph, toolId, "completed", "Delegated to Developer");
+  finishNode(graph, stageId, "completed", "Stage complete");
+  writeGraph(tempDir, cycle.slug, graph);
+
+  const reloadedCycle = readCycle(tempDir, cycle.slug);
+  const reloadedGraph = readGraph(tempDir, cycle.slug);
+  if (!reloadedCycle || !reloadedGraph) {
+    throw new Error("Failed to reload cycle artifacts");
+  }
+
+  const worktreePath = getCycleWorktreePath("/repo", cycle.slug);
+  const branchName = getCycleBranchName("feat", cycle.slug);
+  const ensured = await ensureCycleWorktree("/repo", cycle.slug, "feat", async (_command, args) => {
+    if (args[0] === "branch") return { stdout: "", stderr: "", exitCode: 0 };
+    if (args[0] === "worktree" && args[2] === "--porcelain") return { stdout: "", stderr: "", exitCode: 0 };
+    return { stdout: "", stderr: "", exitCode: 0 };
+  });
+
+  console.log("smoke:ok");
+  console.log(reloadedCycle.slug);
+  console.log(buildPlainStatusLines(reloadedCycle, reloadedGraph).slice(0, 4).join(" | "));
+  console.log(`${worktreePath} :: ${branchName} :: reused=${ensured.reused}`);
+} finally {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}

--- a/.pi/extensions/dev-cycle/stages.test.ts
+++ b/.pi/extensions/dev-cycle/stages.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  approveStage,
+  buildIssuePrompt,
+  buildPlanPrompt,
+  buildPrdPrompt,
+  createCycleRecord,
+  createSliceIssueBody,
+  determineCurrentStage,
+  parsePrdDraft,
+  parseSliceDraft,
+} from "./stages.js";
+
+describe("stages", () => {
+  it("creates planned cycles with PRD as the first stage", () => {
+    const cycle = createCycleRecord("/repo", "Build a dev cycle extension", [
+      "As a developer, I want planning.",
+      "As a developer, I want implementation.",
+    ]);
+
+    expect(cycle.currentStage).toBe("prd");
+    expect(cycle.classification.route).toBe("planned");
+  });
+
+  it("advances after approvals", () => {
+    const cycle = createCycleRecord("/repo", "Build a dev cycle extension", [
+      "As a developer, I want planning.",
+      "As a developer, I want implementation.",
+    ]);
+
+    approveStage(cycle, "prd");
+    expect(determineCurrentStage(cycle)).toBe("issues");
+    approveStage(cycle, "issues");
+    expect(determineCurrentStage(cycle)).toBe("plan");
+  });
+
+  it("parses fenced PRD and slice JSON", () => {
+    const prd = parsePrdDraft('```json\n{"title":"PRD: Demo","body":"## Problem Statement"}\n```');
+    const slices = parseSliceDraft('```json\n[{"title":"Slice","type":"AFK","summary":"One","acceptanceCriteria":["A"],"blockedBy":[],"userStories":[1]}]\n```');
+
+    expect(prd.title).toBe("PRD: Demo");
+    expect(slices[0].title).toBe("Slice");
+  });
+
+  it("builds prompts and issue bodies from cycle data", () => {
+    const cycle = createCycleRecord("/repo", "Build a dev cycle extension", ["As a developer, I want planning."]);
+    cycle.artifacts.prdIssueNumber = 14;
+    cycle.artifacts.prdBody = "## Problem Statement\nTest";
+    cycle.artifacts.slices = [
+      {
+        title: "Cycle shell",
+        type: "AFK",
+        summary: "Create the shell",
+        acceptanceCriteria: ["It exists"],
+        blockedBy: [],
+        userStories: [1],
+      },
+    ];
+
+    expect(buildPrdPrompt(cycle)).toContain("## Problem Statement");
+    expect(buildIssuePrompt(cycle)).toContain("PRD title");
+    expect(buildPlanPrompt(cycle)).toContain("Approved slices");
+    expect(createSliceIssueBody(cycle, cycle.artifacts.slices[0], [])).toContain("#14");
+  });
+});

--- a/.pi/extensions/dev-cycle/stages.ts
+++ b/.pi/extensions/dev-cycle/stages.ts
@@ -1,0 +1,313 @@
+import { classifyRequest, deriveCycleTitle, inferBranchType, normalizeUserStories, slugify } from "./classify.js";
+import type {
+  BranchType,
+  CycleRecord,
+  CycleStageKey,
+  SliceIssue,
+  StageArtifactState,
+} from "./types.js";
+
+type IssueRef = { number: number; url: string };
+
+const STAGE_KEYS: CycleStageKey[] = [
+  "classify",
+  "prd",
+  "issues",
+  "plan",
+  "implementation",
+  "verification",
+  "closed",
+];
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function emptyStage(status: StageArtifactState["status"] = "pending"): StageArtifactState {
+  return { status };
+}
+
+export function createCycleRecord(
+  cwd: string,
+  problem: string,
+  userStoriesInput?: string | string[],
+  branchTypeInput?: BranchType,
+  preferredSlug?: string,
+): CycleRecord {
+  const userStories = normalizeUserStories(userStoriesInput);
+  const branchType = branchTypeInput ?? inferBranchType(problem, userStories);
+  const title = deriveCycleTitle(problem, userStories);
+  const slug = preferredSlug ? slugify(preferredSlug) : slugify(title);
+  const classification = classifyRequest({ problem, userStories, branchType });
+
+  const stages = Object.fromEntries(STAGE_KEYS.map((key) => [key, emptyStage()])) as CycleRecord["stages"];
+  stages.classify = { status: "completed", startedAt: now(), completedAt: now(), note: classification.rationale };
+
+  if (classification.route === "quickfix") {
+    stages.prd = { status: "skipped", note: "Quickfix route" };
+    stages.issues = { status: "skipped", note: "Quickfix route" };
+    stages.plan = { status: "skipped", note: "Quickfix route" };
+  }
+
+  return {
+    version: 1,
+    slug,
+    title,
+    createdAt: now(),
+    updatedAt: now(),
+    cwd,
+    request: { problem, userStories, branchType },
+    classification,
+    currentStage: classification.route === "quickfix" ? "implementation" : "prd",
+    approvals: { prd: false, issues: false, plan: false },
+    stages,
+    artifacts: {},
+    history: [`Cycle created: ${title}`],
+  };
+}
+
+export function touchCycle(cycle: CycleRecord, message?: string): CycleRecord {
+  cycle.updatedAt = now();
+  if (message) cycle.history.unshift(`${cycle.updatedAt} ${message}`);
+  return cycle;
+}
+
+export function stageNeedsApproval(stage: CycleStageKey): stage is "prd" | "issues" | "plan" {
+  return stage === "prd" || stage === "issues" || stage === "plan";
+}
+
+export function determineCurrentStage(cycle: CycleRecord): CycleStageKey {
+  if (cycle.stages.implementation.status === "failed") return "implementation";
+  if (cycle.stages.verification.status === "failed") return "verification";
+
+  if (cycle.classification.route === "planned") {
+    if (!cycle.approvals.prd) return "prd";
+    if (!cycle.approvals.issues) return "issues";
+    if (!cycle.approvals.plan) return "plan";
+  }
+
+  if (cycle.stages.implementation.status !== "completed") return "implementation";
+  if (cycle.stages.verification.status !== "completed") return "verification";
+  return "closed";
+}
+
+export function approveStage(cycle: CycleRecord, stage: "prd" | "issues" | "plan"): CycleRecord {
+  cycle.approvals[stage] = true;
+  cycle.stages[stage].status = "approved";
+  cycle.stages[stage].completedAt = now();
+  touchCycle(cycle, `Approved ${stage}`);
+  cycle.currentStage = determineCurrentStage(cycle);
+  return cycle;
+}
+
+function extractJsonBlock<T>(text: string): T {
+  const fenced = text.match(/```json\s*\n([\s\S]*?)\n```/);
+  const source = fenced?.[1] ?? text;
+  return JSON.parse(source) as T;
+}
+
+export function buildPrdPrompt(cycle: CycleRecord): string {
+  return [
+    "You are writing a product requirements document for a dev-cycle extension.",
+    "Return exactly one JSON object inside a ```json fence with this shape:",
+    '{ "title": "PRD: ...", "body": "## Problem Statement\\n..." }',
+    "The body must include these headings in order:",
+    "## Problem Statement",
+    "## Solution",
+    "## User Stories",
+    "## Implementation Decisions",
+    "## Testing Decisions",
+    "## Out of Scope",
+    "## Further Notes",
+    "",
+    `Problem statement: ${cycle.request.problem}`,
+    cycle.request.userStories.length > 0
+      ? `User stories:\n${cycle.request.userStories.map((story, index) => `${index + 1}. ${story}`).join("\n")}`
+      : "User stories: none supplied; infer an appropriate set from the problem statement.",
+    "",
+    "Be specific, concise, and implementation-ready.",
+  ].join("\n");
+}
+
+export function parsePrdDraft(text: string): { title: string; body: string } {
+  return extractJsonBlock<{ title: string; body: string }>(text);
+}
+
+export function buildIssuePrompt(cycle: CycleRecord): string {
+  return [
+    "Break this approved PRD into thin vertical slices.",
+    "Return exactly one JSON array inside a ```json fence. Each item must have:",
+    '{ "title": "...", "type": "AFK", "summary": "...", "acceptanceCriteria": ["..."], "blockedBy": ["other title"], "userStories": [1, 2] }',
+    "Prefer AFK slices. Use dependency titles in blockedBy; they will be resolved later.",
+    "",
+    `PRD title: ${cycle.artifacts.prdTitle ?? cycle.title}`,
+    cycle.artifacts.prdBody ?? "",
+  ].join("\n");
+}
+
+export function parseSliceDraft(text: string): SliceIssue[] {
+  return extractJsonBlock<SliceIssue[]>(text);
+}
+
+export function buildPlanPrompt(cycle: CycleRecord): string {
+  const sliceSummary = (cycle.artifacts.slices ?? [])
+    .map((slice, index) => {
+      const blockedBy = slice.blockedBy.length > 0 ? `blocked by: ${slice.blockedBy.join(", ")}` : "no blockers";
+      return `${index + 1}. ${slice.title} (${blockedBy})`;
+    })
+    .join("\n");
+
+  return [
+    "Write a phased implementation plan in markdown.",
+    "Use this structure:",
+    "# Plan: <Feature Name>",
+    "> Source PRD: <identifier>",
+    "## Architectural decisions",
+    "---",
+    "## Phase 1: <Title>",
+    "**User stories**: ...",
+    "### What to build",
+    "### Acceptance criteria",
+    "",
+    `Cycle title: ${cycle.title}`,
+    `Source PRD issue: #${cycle.artifacts.prdIssueNumber ?? "unknown"}`,
+    `Approved slices:\n${sliceSummary}`,
+    "",
+    "Keep the plan high-signal, with durable decisions and thin vertical slices.",
+  ].join("\n");
+}
+
+export function createSliceIssueBody(
+  cycle: CycleRecord,
+  slice: SliceIssue,
+  blockedByNumbers: number[],
+): string {
+  return [
+    "## Parent PRD",
+    "",
+    `#${cycle.artifacts.prdIssueNumber}`,
+    "",
+    "## What to build",
+    "",
+    slice.summary,
+    "",
+    "## Acceptance criteria",
+    "",
+    ...slice.acceptanceCriteria.map((criterion) => `- [ ] ${criterion}`),
+    "",
+    "## Blocked by",
+    "",
+    blockedByNumbers.length > 0
+      ? blockedByNumbers.map((value) => `- Blocked by #${value}`).join("\n")
+      : "None - can start immediately",
+    "",
+    "## User stories addressed",
+    "",
+    ...slice.userStories.map((story) => `- User story ${story}`),
+    "",
+  ].join("\n");
+}
+
+export async function runPrdStage(
+  cycle: CycleRecord,
+  runPlanner: (prompt: string) => Promise<string>,
+  createIssue: (title: string, body: string) => Promise<IssueRef>,
+): Promise<CycleRecord> {
+  cycle.stages.prd = { status: "running", startedAt: now() };
+  const draft = parsePrdDraft(await runPlanner(buildPrdPrompt(cycle)));
+  const issue = await createIssue(draft.title, draft.body);
+  cycle.artifacts.prdTitle = draft.title;
+  cycle.artifacts.prdBody = draft.body;
+  cycle.artifacts.prdIssueNumber = issue.number;
+  cycle.artifacts.prdIssueUrl = issue.url;
+  cycle.stages.prd = {
+    status: "awaiting_approval",
+    startedAt: cycle.stages.prd.startedAt,
+    completedAt: now(),
+    note: issue.url,
+  };
+  touchCycle(cycle, `Created PRD issue #${issue.number}`);
+  cycle.currentStage = "prd";
+  return cycle;
+}
+
+export async function runIssueStage(
+  cycle: CycleRecord,
+  runPlanner: (prompt: string) => Promise<string>,
+  createIssue: (title: string, body: string) => Promise<IssueRef>,
+): Promise<CycleRecord> {
+  cycle.stages.issues = { status: "running", startedAt: now() };
+  const slices = parseSliceDraft(await runPlanner(buildIssuePrompt(cycle)));
+
+  const created = new Map<string, number>();
+  for (const slice of slices) {
+    const blockedByNumbers = slice.blockedBy.map((title) => created.get(title)).filter((value): value is number => value !== undefined);
+    const issue = await createIssue(slice.title, createSliceIssueBody(cycle, slice, blockedByNumbers));
+    slice.issueNumber = issue.number;
+    slice.issueUrl = issue.url;
+    created.set(slice.title, issue.number);
+  }
+
+  cycle.artifacts.slices = slices;
+  cycle.stages.issues = {
+    status: "awaiting_approval",
+    startedAt: cycle.stages.issues.startedAt,
+    completedAt: now(),
+    note: `${slices.length} slices created`,
+  };
+  touchCycle(cycle, `Created ${slices.length} slice issues`);
+  cycle.currentStage = "issues";
+  return cycle;
+}
+
+export async function runPlanStage(
+  cycle: CycleRecord,
+  runPlanner: (prompt: string) => Promise<string>,
+  writePlan: (markdown: string) => string,
+): Promise<CycleRecord> {
+  cycle.stages.plan = { status: "running", startedAt: now() };
+  const markdown = await runPlanner(buildPlanPrompt(cycle));
+  const planPath = writePlan(markdown);
+  cycle.artifacts.planMarkdown = markdown;
+  cycle.artifacts.planPath = planPath;
+  cycle.stages.plan = {
+    status: "awaiting_approval",
+    startedAt: cycle.stages.plan.startedAt,
+    completedAt: now(),
+    note: planPath,
+  };
+  touchCycle(cycle, `Wrote plan ${planPath}`);
+  cycle.currentStage = "plan";
+  return cycle;
+}
+
+export function markImplementationStarted(cycle: CycleRecord): CycleRecord {
+  cycle.stages.implementation = { status: "running", startedAt: now() };
+  cycle.currentStage = "implementation";
+  return touchCycle(cycle, "Implementation started");
+}
+
+export function markImplementationFinished(cycle: CycleRecord, summary: string): CycleRecord {
+  cycle.stages.implementation = {
+    status: "completed",
+    startedAt: cycle.stages.implementation.startedAt,
+    completedAt: now(),
+    note: summary,
+  };
+  cycle.artifacts.implementationSummary = summary;
+  cycle.currentStage = "verification";
+  return touchCycle(cycle, "Implementation finished");
+}
+
+export function markVerificationFinished(cycle: CycleRecord, summary: string): CycleRecord {
+  cycle.stages.verification = {
+    status: "completed",
+    startedAt: cycle.stages.verification.startedAt ?? now(),
+    completedAt: now(),
+    note: summary,
+  };
+  cycle.artifacts.verificationSummary = summary;
+  cycle.currentStage = "closed";
+  cycle.stages.closed = { status: "completed", startedAt: now(), completedAt: now(), note: "Cycle complete" };
+  return touchCycle(cycle, "Verification finished");
+}

--- a/.pi/extensions/dev-cycle/types.ts
+++ b/.pi/extensions/dev-cycle/types.ts
@@ -1,0 +1,190 @@
+export type BranchType = "feat" | "fix" | "chore";
+
+export type CycleRoute = "quickfix" | "planned";
+
+export type CycleStageKey =
+  | "classify"
+  | "prd"
+  | "issues"
+  | "plan"
+  | "implementation"
+  | "verification"
+  | "closed";
+
+export type StageStatus =
+  | "pending"
+  | "running"
+  | "awaiting_approval"
+  | "approved"
+  | "completed"
+  | "skipped"
+  | "failed";
+
+export interface CycleRequest {
+  problem: string;
+  userStories: string[];
+  branchType: BranchType;
+}
+
+export interface CycleClassification {
+  route: CycleRoute;
+  rationale: string;
+  confidence: "low" | "medium" | "high";
+  requiredStages: CycleStageKey[];
+}
+
+export interface SliceIssue {
+  title: string;
+  type: "AFK" | "HITL";
+  summary: string;
+  acceptanceCriteria: string[];
+  blockedBy: string[];
+  userStories: number[];
+  issueNumber?: number;
+  issueUrl?: string;
+}
+
+export interface StageArtifactState {
+  status: StageStatus;
+  startedAt?: string;
+  completedAt?: string;
+  error?: string;
+  note?: string;
+}
+
+export interface CycleArtifacts {
+  prdTitle?: string;
+  prdBody?: string;
+  prdIssueNumber?: number;
+  prdIssueUrl?: string;
+  slices?: SliceIssue[];
+  planMarkdown?: string;
+  planPath?: string;
+  worktreePath?: string;
+  branchName?: string;
+  implementationSummary?: string;
+  verificationSummary?: string;
+  executionGraphPath?: string;
+}
+
+export interface CycleRecord {
+  version: 1;
+  slug: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  cwd: string;
+  request: CycleRequest;
+  classification: CycleClassification;
+  currentStage: CycleStageKey;
+  approvals: {
+    prd: boolean;
+    issues: boolean;
+    plan: boolean;
+  };
+  stages: Record<CycleStageKey, StageArtifactState>;
+  artifacts: CycleArtifacts;
+  history: string[];
+}
+
+export type ExecutionNodeKind = "cycle" | "stage" | "agent" | "tool";
+
+export type ExecutionNodeStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "aborted";
+
+export interface ExecutionNode {
+  id: string;
+  parentId: string | null;
+  kind: ExecutionNodeKind;
+  label: string;
+  status: ExecutionNodeStatus;
+  startedAt: string;
+  endedAt?: string;
+  detail?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+  children: string[];
+}
+
+export interface ExecutionGraph {
+  cycleSlug: string;
+  rootId: string;
+  nodes: Record<string, ExecutionNode>;
+  updatedAt: string;
+}
+
+export interface UsageTotals {
+  input: number;
+  output: number;
+  cost: number;
+  turns: number;
+}
+
+export interface DiscoveredAgent {
+  name: string;
+  slug: string;
+  description: string;
+  category: string;
+  source: "built-in" | "project" | "user";
+  model?: string;
+  tools?: string[];
+  systemPrompt: string;
+  filePath: string;
+}
+
+export interface CycleStatusView {
+  slug: string;
+  title: string;
+  route: CycleRoute;
+  currentStage: CycleStageKey;
+  approvals: CycleRecord["approvals"];
+  worktreePath?: string;
+  branchName?: string;
+}
+
+export interface PiRunOptions {
+  cwd: string;
+  systemPrompt: string;
+  task: string;
+  allowExtensions?: boolean;
+  model?: string;
+  tools?: string[];
+  env?: Record<string, string>;
+  signal?: AbortSignal;
+  graph?: ExecutionGraph;
+  parentNodeId?: string;
+  nodeLabel?: string;
+  onGraphUpdate?: (graph: ExecutionGraph) => void;
+}
+
+export interface PiRunResult {
+  exitCode: number;
+  output: string;
+  stderr: string;
+  stopReason?: string;
+  errorMessage?: string;
+  usage: UsageTotals;
+  rootNodeId: string;
+  graph: ExecutionGraph;
+}
+
+export interface SubagentTask {
+  agent: string;
+  task: string;
+  cwd?: string;
+}
+
+export interface SubagentResult {
+  agent: string;
+  source: "built-in" | "project" | "user" | "unknown";
+  task: string;
+  exitCode: number;
+  output: string;
+  stderr: string;
+  usage: UsageTotals;
+  model?: string;
+  graph?: ExecutionGraph;
+}

--- a/.pi/extensions/dev-cycle/ui.test.ts
+++ b/.pi/extensions/dev-cycle/ui.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createExecutionGraph, addNode, finishNode } from "./graph.js";
+import { createCycleRecord } from "./stages.js";
+import { buildPlainStatusLines, buildStatusLine, renderExecutionTree } from "./ui.js";
+
+describe("ui helpers", () => {
+  it("builds a compact status line", () => {
+    const cycle = createCycleRecord("/repo", "Fix cycle output");
+    expect(buildStatusLine(cycle)).toContain("implementation");
+  });
+
+  it("renders a recursive execution tree", () => {
+    const graph = createExecutionGraph("demo", "Demo");
+    const stageId = addNode(graph, graph.rootId, "stage", "Implementation stage", "running");
+    const agentId = addNode(graph, stageId, "agent", "Engineering Orchestrator", "running");
+    finishNode(graph, agentId, "completed", "Done");
+
+    const lines = renderExecutionTree(graph);
+    expect(lines.join("\n")).toContain("Implementation stage");
+    expect(lines.join("\n")).toContain("Engineering Orchestrator");
+  });
+
+  it("builds plain status lines with worktree info", () => {
+    const cycle = createCycleRecord("/repo", "Build a dev cycle extension", ["As a user, I want planning."]);
+    cycle.artifacts.worktreePath = "/repo/.worktrees/cycles/demo";
+    cycle.artifacts.branchName = "feat/demo";
+
+    const lines = buildPlainStatusLines(cycle, null);
+    expect(lines.join("\n")).toContain("feat/demo");
+    expect(lines.join("\n")).toContain(".worktrees/cycles/demo");
+  });
+});

--- a/.pi/extensions/dev-cycle/ui.ts
+++ b/.pi/extensions/dev-cycle/ui.ts
@@ -1,0 +1,102 @@
+import type { CycleRecord, ExecutionGraph, ExecutionNodeStatus } from "./types.js";
+
+export interface WidgetTheme {
+  fg: (color: string, text: string) => string;
+  bold: (text: string) => string;
+}
+
+const STATUS_ICON: Record<ExecutionNodeStatus, string> = {
+  queued: "○",
+  running: "▶",
+  completed: "✓",
+  failed: "✗",
+  aborted: "⊘",
+};
+
+const STATUS_COLOR: Record<ExecutionNodeStatus, string> = {
+  queued: "muted",
+  running: "accent",
+  completed: "success",
+  failed: "error",
+  aborted: "warning",
+};
+
+export function buildStatusLine(cycle: CycleRecord): string {
+  const approvals = [
+    cycle.approvals.prd ? "prd" : "",
+    cycle.approvals.issues ? "issues" : "",
+    cycle.approvals.plan ? "plan" : "",
+  ].filter(Boolean);
+
+  const approvalText = approvals.length > 0 ? ` | approved: ${approvals.join(", ")}` : "";
+  return `${cycle.slug} | ${cycle.classification.route} | ${cycle.currentStage}${approvalText}`;
+}
+
+export function buildPlainStatusLines(cycle: CycleRecord, graph: ExecutionGraph | null): string[] {
+  const lines = [
+    `Cycle: ${cycle.title} (${cycle.slug})`,
+    `Route: ${cycle.classification.route}`,
+    `Current stage: ${cycle.currentStage}`,
+    `Approvals: prd=${cycle.approvals.prd} issues=${cycle.approvals.issues} plan=${cycle.approvals.plan}`,
+  ];
+
+  if (cycle.artifacts.worktreePath) lines.push(`Worktree: ${cycle.artifacts.worktreePath}`);
+  if (cycle.artifacts.branchName) lines.push(`Branch: ${cycle.artifacts.branchName}`);
+
+  if (graph) {
+    lines.push("");
+    lines.push("Execution tree:");
+    lines.push(...renderExecutionTree(graph));
+  }
+
+  return lines;
+}
+
+export function buildWidgetLines(cycle: CycleRecord, graph: ExecutionGraph | null, theme: WidgetTheme): string[] {
+  const lines: string[] = [];
+  lines.push(theme.bold(theme.fg("accent", "DEV CYCLE")));
+  lines.push(theme.fg("muted", cycle.title));
+  lines.push(theme.fg("dim", `${cycle.slug} · ${cycle.currentStage} · ${cycle.classification.route}`));
+  lines.push("");
+  lines.push(
+    theme.fg(
+      "muted",
+      `Approvals: prd=${cycle.approvals.prd} issues=${cycle.approvals.issues} plan=${cycle.approvals.plan}`,
+    ),
+  );
+
+  if (cycle.artifacts.worktreePath) {
+    lines.push(theme.fg("muted", `Worktree: ${cycle.artifacts.worktreePath}`));
+  }
+
+  if (graph) {
+    lines.push("");
+    lines.push(theme.bold(theme.fg("muted", "Execution tree")));
+    lines.push(...renderExecutionTree(graph, theme));
+  }
+
+  return lines;
+}
+
+export function renderExecutionTree(graph: ExecutionGraph, theme?: WidgetTheme): string[] {
+  return renderNode(graph, graph.rootId, 0, theme);
+}
+
+function renderNode(graph: ExecutionGraph, nodeId: string, depth: number, theme?: WidgetTheme): string[] {
+  const node = graph.nodes[nodeId];
+  if (!node) return [];
+
+  const prefix = `${"  ".repeat(depth)}${STATUS_ICON[node.status]} `;
+  const label = theme
+    ? theme.fg(STATUS_COLOR[node.status], `${prefix}${node.label}`)
+    : `${prefix}${node.label}`;
+  const detail = node.detail ? `${"  ".repeat(depth + 1)}${node.detail.split("\n")[0]}` : null;
+  const lines = [label];
+  if (detail) lines.push(theme ? theme.fg("dim", detail) : detail);
+
+  for (const childId of node.children) {
+    lines.push(...renderNode(graph, childId, depth + 1, theme));
+  }
+
+  return lines;
+}

--- a/.pi/extensions/dev-cycle/worktree.test.ts
+++ b/.pi/extensions/dev-cycle/worktree.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { ensureCycleWorktree, getCycleBranchName, getCycleWorktreePath } from "./worktree.js";
+
+describe("worktree helpers", () => {
+  it("derives worktree paths and branch names", () => {
+    expect(getCycleWorktreePath("/repo", "my-cycle")).toBe("/repo/.worktrees/cycles/my-cycle");
+    expect(getCycleBranchName("feat", "my-cycle")).toBe("feat/my-cycle");
+  });
+
+  it("reuses an existing worktree", async () => {
+    const calls: string[] = [];
+    const execLike = async (command: string, args: string[], cwd: string) => {
+      calls.push(`${command} ${args.join(" ")} @ ${cwd}`);
+      if (args[0] === "branch") return { stdout: "  feat/my-cycle\n", stderr: "", exitCode: 0 };
+      return {
+        stdout: "worktree /repo/.worktrees/cycles/my-cycle\nbranch refs/heads/feat/my-cycle\n",
+        stderr: "",
+        exitCode: 0,
+      };
+    };
+
+    const result = await ensureCycleWorktree("/repo", "my-cycle", "feat", execLike);
+    expect(result.reused).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("creates a new branch when no worktree exists yet", async () => {
+    const calls: string[] = [];
+    const execLike = async (_command: string, args: string[], _cwd: string) => {
+      calls.push(args.join(" "));
+      if (args[0] === "branch") return { stdout: "", stderr: "", exitCode: 0 };
+      if (args[0] === "worktree" && args[2] === "--porcelain") return { stdout: "", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    };
+
+    const result = await ensureCycleWorktree("/repo", "my-cycle", "feat", execLike);
+    expect(result.reused).toBe(false);
+    expect(calls.at(-1)).toContain("-b feat/my-cycle");
+  });
+});

--- a/.pi/extensions/dev-cycle/worktree.ts
+++ b/.pi/extensions/dev-cycle/worktree.ts
@@ -1,0 +1,47 @@
+import * as path from "node:path";
+import type { BranchType } from "./types.js";
+
+export interface ExecLikeResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export type ExecLike = (command: string, args: string[], cwd: string) => Promise<ExecLikeResult>;
+
+export function getCycleWorktreePath(repoRoot: string, slug: string): string {
+  return path.join(repoRoot, ".worktrees", "cycles", slug);
+}
+
+export function getCycleBranchName(branchType: BranchType, slug: string): string {
+  return `${branchType}/${slug}`;
+}
+
+export async function ensureCycleWorktree(
+  repoRoot: string,
+  slug: string,
+  branchType: BranchType,
+  execLike: ExecLike,
+): Promise<{ path: string; branch: string; reused: boolean }> {
+  const worktreePath = getCycleWorktreePath(repoRoot, slug);
+  const branchName = getCycleBranchName(branchType, slug);
+
+  const branchCheck = await execLike("git", ["branch", "--list", branchName], repoRoot);
+  const branchExists = branchCheck.stdout.trim().length > 0;
+
+  const worktreeList = await execLike("git", ["worktree", "list", "--porcelain"], repoRoot);
+  const alreadyExists = worktreeList.stdout.includes(`worktree ${worktreePath}`);
+  if (alreadyExists) {
+    return { path: worktreePath, branch: branchName, reused: true };
+  }
+
+  const args = branchExists
+    ? ["worktree", "add", worktreePath, branchName]
+    : ["worktree", "add", "-b", branchName, worktreePath];
+  const created = await execLike("git", args, repoRoot);
+  if (created.exitCode !== 0) {
+    throw new Error(created.stderr || `Failed to create worktree ${worktreePath}`);
+  }
+
+  return { path: worktreePath, branch: branchName, reused: false };
+}


### PR DESCRIPTION
## Summary
- add a new `dev-cycle` Pi extension that can classify requests, persist resumable cycle state, generate PRD/issues/plan artifacts, and gate implementation behind explicit approvals plus an explicit start trigger
- provision or reuse cycle worktrees under `.worktrees/cycles/<slug>`, discover built-in/project/user agents, and launch implementation + verification through an orchestrator with a live recursive execution graph
- add unit coverage for the extension modules plus a lightweight runtime smoke harness for local end-to-end module checks without live model or GitHub dependencies

## Test plan
- [x] `cd .pi/extensions/dev-cycle && npm test -- --run`
- [x] `cd .pi/extensions/dev-cycle && npx vite-node smoke-temp.ts`
- [ ] Manual Pi UI smoke test of slash commands and live widget rendering

Closes #14
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21
Closes #22
Closes #23

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a sizable new Pi extension that writes local state under `.pi/dev-cycles/`, shells out to `git`, `gh`, and `pi` subprocesses, and orchestrates multi-stage flows; failures could impact developer workflow/state and issue/worktree creation. Changes are mostly additive and isolated, but touch process execution and filesystem behavior.
> 
> **Overview**
> Introduces a new `dev-cycle` Pi extension that manages a resumable workflow from intake through PRD/issue slicing/plan generation (with explicit approvals) to implementation and verification, with persisted cycle state and a live execution graph.
> 
> Implements agent discovery across built-in/user/project directories, a `cycle_subagent` delegation tool with depth limits, and automatic creation/reuse of per-cycle `git worktree` branches. Adds helpers for artifact persistence, GitHub issue creation via `gh`, a `pi` JSON-runner that tracks tool/agent nodes, UI/status rendering, and comprehensive Vitest coverage.
> 
> Updates `.gitignore` to exclude `.pi/dev-cycles/` runtime storage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e71c3eea5abb5a4d72f3447de76480a3f66f5a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->